### PR TITLE
Modernize Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.579</version>
+    <version>4.40</version>
+    <relativePath/>
   </parent>
   
   <artifactId>show-build-parameters</artifactId>
@@ -27,6 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jenkins.version>2.303.3</jenkins.version>
   </properties>
 
   <repositories>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default="true"?>
 <div>
   This plugin shows the parameter values on the main build page
 </div>

--- a/src/main/resources/jenkins/plugins/show_build_parameters/ShowParametersBuildAction/summary.jelly
+++ b/src/main/resources/jenkins/plugins/show_build_parameters/ShowParametersBuildAction/summary.jelly
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
+<?jelly escape-by-default="true"?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${!it.parameters.isEmpty()}">
     <t:summary icon="document.gif">


### PR DESCRIPTION
Hi @petehayes, I made some updates to this plugin to bring it inline with current tooling and [Jenkins version recommendations](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/). The biggest benefit of upgrading the core version is to avoid implicit dependencies. 

- Upgrade parent pom to 4.40
- Upgrade jenkins.core to 2.303.3 to avoid implicit dependencies
- Include jelly escape-by-default (required by new tooling)